### PR TITLE
Fix bug in word count example

### DIFF
--- a/examples/wordCount.js
+++ b/examples/wordCount.js
@@ -34,7 +34,7 @@ stream
 stream.start();
 
 //consume & produce for 5 seconds
-setTimeout(kafkaStreams.closeAll().bind(kafkaStreams), 5000);
+setTimeout(kafkaStreams.closeAll.bind(kafkaStreams), 5000);
 
 function keyValueMapperEtl(message){
     const elements = message.toLowerCase().split(" ");


### PR DESCRIPTION
The word count example was not working. `.bind()` needs to be run on the function, not the return value of the function.