### PR TITLE
Fix to keep support for node versions between 6.10 and 7.6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "debug": "^3.1.0",
     "most": "^1.7.2",
     "most-subject": "^5.3.0",
-    "sinek": "^6.2.2"
+    "sinek": "6.2.2"
   },
   "devDependencies": {
     "async": "~2.6.0",


### PR DESCRIPTION
Because sinek has had an update that uses `async-await` as a minor update to version `6.x.x`, it's necessary to lock the version to a known good version in order to keep backwards compatibility.