### PR TITLE
Update typescript def to define return type for to()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -123,7 +123,7 @@ declare module "kafka-streams" {
         min(fieldName: string, minField?: string): StreamDSL;
         max(fieldName: string, maxField?: string): StreamDSL;
         to(topic: string, outputPartitionsCount?: number, produceType?: "send" | "buffer" | "bufferFormat",
-            version?: number, compressionType?: number, producerErrorCallback?: (error: Error) => void, outputKafkaConfig?: IKafkaStreamsConfig);
+            version?: number, compressionType?: number, producerErrorCallback?: (error: Error) => void, outputKafkaConfig?: IKafkaStreamsConfig): StreamDSL;
     }
 
     export class KStream extends StreamDSL {


### PR DESCRIPTION
Using TS 3.0.3 receive this error on build when being strict: 

`error TS7010: 'to', which lacks return-type annotation, implicitly has an 'any' return type.`

This fix ensures that StreamDSL is returned.