### PR TITLE
StreamDSL to() method parameter type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -122,7 +122,7 @@ declare module "kafka-streams" {
         sumByKey(key: string, fieldName: string, sumField: boolean): StreamDSL;
         min(fieldName: string, minField?: string): StreamDSL;
         max(fieldName: string, maxField?: string): StreamDSL;
-        to(topic?: string, outputPartitionsCount?: number, produceType?: "send" | "buffer" | "bufferFormat",
+        to(topic?: string, outputPartitionsCount?: number | 'auto', produceType?: "send" | "buffer" | "bufferFormat",
             version?: number, compressionType?: number, producerErrorCallback?: (error: Error) => void,
             outputKafkaConfig?: IKafkaStreamsConfig): Promise<boolean>;
     }


### PR DESCRIPTION
Updated outputPartitionsCount parameter type in `index.d.ts` of the `to()` StreamDSL method to allow the string 'auto'.

This parameter type is currently `outputPartitionsCount?: number`. By passing undefined, the default numerical value is used: `outputPartitionsCount = 1` (as seen in https://github.com/nodefluent/kafka-streams/blob/master/lib/dsl/StreamDSL.js#L1010). 

It should also be permissible to pass the string `auto` to allow automatic handling of the partitions, which is permitted by the JavaScript in `StreamDSL.js`.