### PR TITLE
Corrected type of first argument of start method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -131,7 +131,7 @@ declare module "kafka-streams" {
         constructor(topicName: string, storage?: KStorage, kafka?: KafkaClient, isClone?: boolean);
         start(kafkaReadyCallback?: () => void, kafkaErrorCallback?: (error: Error) => void,
             withBackPressure?: boolean, outputKafkaConfig?: IKafkaStreamsConfig): Promise<void>;
-        start({ outputKafkaConfig: IKafkaStreamsConfig }): Promise<void>;
+        start(config: { outputKafkaConfig?: IKafkaStreamsConfig }): Promise<void>;
         innerJoin(stream: KStream, key?: string, windowed?: boolean, combine?: Function): KStream;
         merge(stream: KStream): KStream;
         fromMost(stream$: any): KStream;


### PR DESCRIPTION
The previous type was not valid TypeScript.

This correction types the first argument of the `start` method overload as an object, possibly containing the key `outputKafkaConfig`, whose value (if the key is present) is an object of type `IKafkaStreamsConfig`.