### PR TITLE
Fix index.d.ts compiling error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -166,7 +166,7 @@ declare module "kafka-streams" {
     }
 
     export class Window {
-        constructor(container: [], collect: boolean);
+        constructor(container: any[], collect: boolean);
         getStream(): KStream;
         execute(element: any, leaveEncapsulated: boolean): void;
         writeToStream(): void;


### PR DESCRIPTION
The kafka-streams is failing to build when I'm using it with type script throwing the following error:
 
node_modules/kafka-streams/index.d.ts(169,32): error TS1122: A tuple type element list cannot be empty.