### PR TITLE
Fix incorrect type definition for KStream.branch()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -245,7 +245,7 @@ declare module "kafka-streams" {
         fromMost(stream$: any): KStream;
         clone(): KStream;
         window(from: number, to: number, etl?: null | ((message: any) => any), encapsulated?: boolean): { window: Window, abort: () => void, stream: KStream };
-        branch(preds: (message: any) => boolean[]): KStream[];
+        branch(preds: ((message: any) => boolean)[]): KStream[];
         close(): Promise<boolean>;
     }
 


### PR DESCRIPTION
According to the example in `consumeOneProduceTwoTopics.js` we have:
```
const [one$, two$] = stream$
    .branch([() => true, () => true]);
```
but `index.d.ts` says `branch()` wants _one_ predicate that returns an array of booleans. It should be an _array of predicates_ that return boolean.