### PR TITLE
Prevent mapJSONConvenience from mutating original data

### DIFF
--- a/lib/dsl/StreamDSL.js
+++ b/lib/dsl/StreamDSL.js
@@ -4,6 +4,7 @@ const EventEmitter = require("events");
 const most = require("most");
 const Promise = require("bluebird");
 const uuid = require("uuid");
+const lodashCloneDeep = require("lodash.clonedeep");
 const debug = require("debug")("kafka-streams:streamdsl");
 
 const KStorage = require("../KStorage.js");
@@ -509,16 +510,18 @@ class StreamDSL {
                 return object;
             }
 
+            let newObject = object;
             try {
                 const value = object.value.toString("utf8");
                 if (value) {
-                    object.value = value;
+                    newObject = lodashCloneDeep(object);
+                    newObject.value = value;
                 }
             } catch (_) {
                 //empty
             }
 
-            return object;
+            return newObject;
         });
     }
 
@@ -539,16 +542,18 @@ class StreamDSL {
                 return object;
             }
 
+            let newObject = object;
             try {
                 const value = JSON.parse(object.value);
                 if (value) {
-                    object.value = value;
+                    newObject = lodashCloneDeep(object);
+                    newObject.value = value;
                 }
             } catch (_) {
                 //empty
             }
 
-            return object;
+            return newObject;
         });
     }
 


### PR DESCRIPTION
This PR is to prevent `mapJSONConvenience` from mutating original message. This is required when using .branch after a `mapJSONConvenience` operation on a stream.

This can fix (or work as a workaround) #147

